### PR TITLE
Setup `sweetalert` for `Turbo.setConfirmMethod()`

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails";
 import "./controllers";
+import "./config";
 import "trix";
 import "@rails/actiontext";
-import "./swal.js";

--- a/app/javascript/config/index.js
+++ b/app/javascript/config/index.js
@@ -1,0 +1,1 @@
+import "./turbo"

--- a/app/javascript/config/turbo.js
+++ b/app/javascript/config/turbo.js
@@ -1,3 +1,6 @@
+import * as Turbo from "@hotwired/turbo"
+import Swal from "sweetalert2"
+
 // From Discord
 // Takes the following data-elements:
 // data-title-text
@@ -6,8 +9,6 @@
 // data-confirm-button-color
 // data-cancel-button-color
 // data-confirm-button-text
-import Swal from "sweetalert2";
-
 Turbo.setConfirmMethod((text, formElement) => {
   const defaults = {
     titleText: "Are you sure?",

--- a/app/javascript/controllers/sweetalert_controller.js
+++ b/app/javascript/controllers/sweetalert_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import Swal from "sweetalert2";
 import { destroy } from "@rails/request.js";
-import { Turbo } from "@hotwired/turbo-rails";
+import * as Turbo from "@hotwired/turbo-rails";
 
 // Connects to data-controller="sweetalert"
 export default class extends Controller {

--- a/app/views/shared/_crud_icons.html.erb
+++ b/app/views/shared/_crud_icons.html.erb
@@ -2,14 +2,8 @@
   <%= render 'shared/edit_icon', edit_path: edit_path, answer: answer %>
   <%= button_to delete_path, method: :delete, title: "Remove Book",
             form: { data: {
-              turbo_confirm: "Are you sure?",
-              turbo: use_turbo,
-              controller: "sweetalert",
-              action: 'click->sweetalert#confirm',
-              "sweetalert-item-value": item_name,
-              "sweetalert-url-value": url,
-              "sweetalert-redirect-value": redirect_url,
-              "sweetalert-answer-value": answer
+              turbo_confirm: "You are about to delete \"#{item_name}\"",
+              confirm_button_text: "Delete"
             } },
             class: "delete-icon nobutton" do %>
     <svg

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": "true",
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",
-    "@hotwired/turbo-rails": "^7.1.3",
+    "@hotwired/turbo-rails": "^7.2.0-beta.2",
     "@rails/actiontext": "^7.0.3-1",
     "@rails/activestorage": "^7.0.3-1",
     "@rails/request.js": "^0.0.6",
@@ -13,6 +13,9 @@
     "sass": "^1.53.0",
     "sweetalert2": "^11.4.24",
     "trix": "^2.0.0-beta.0"
+  },
+  "resolutions": {
+    "@hotwired/turbo": "https://github.com/hotwired/dev-builds/archive/refs/tags/@hotwired/turbo/6fb29e9.tar.gz"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,18 +7,17 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
   integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
 
-"@hotwired/turbo-rails@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.1.3.tgz#a4e04ecb800a06e7f9aa6e298170fa4580b74216"
-  integrity sha512-6qKgn75bMWKx0bJgmSfrdC73EJkGLoSWZPAssvcd3nE7ZpDZff6f67j5OQNjjpRgNB7OFruom6VWguGQGu1fQg==
+"@hotwired/turbo-rails@^7.2.0-beta.2":
+  version "7.2.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.2.0-beta.2.tgz#e4a268f282e0d88410556ac1729ba70f7dd0a6b0"
+  integrity sha512-KlBSQoT36/Ys8iP5L2aW9qLwlIATQiIB63T81/6EsL+UkkJQYrrb2oNyxnO/mdDseDoqKaaYFBrUnd5FqefzbA==
   dependencies:
-    "@hotwired/turbo" "^7.1.0"
+    "@hotwired/turbo" "^7.2.0-beta.2"
     "@rails/actioncable" "^7.0"
 
-"@hotwired/turbo@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.1.0.tgz#27e44e0e3dc5bd1d4bda0766d579cf5a14091cd7"
-  integrity sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA==
+"@hotwired/turbo@^7.2.0-beta.2", "@hotwired/turbo@https://github.com/hotwired/dev-builds/archive/refs/tags/@hotwired/turbo/6fb29e9.tar.gz":
+  version "7.2.0-beta.2"
+  resolved "https://github.com/hotwired/dev-builds/archive/refs/tags/@hotwired/turbo/6fb29e9.tar.gz#96699f3e4a031ebc9ae3e06f06a745128a6cbc88"
 
 "@rails/actioncable@^7.0":
   version "7.0.3"


### PR DESCRIPTION
As per the discussions on Discord.

This PR setups `data-turbo-confirm` to use a custom confirm function which leverages Sweetalert to confirm the action